### PR TITLE
Fixes to make this work in newer development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ PreferenceLoader_LDFLAGS = -L$(THEOS_OBJ_DIR)
 include $(THEOS_MAKE_PATH)/library.mk
 include $(THEOS_MAKE_PATH)/tweak.mk
 
+# Here, PreferenceLoader is expected to be linked against `$(THEOS_OBJ_DIR)/libprefs.dylib`,
+# however a linker tries to use `$THEOS/vendor/lib/libprefs.tbd`,
+# and it fails because `libprefs.tbd` in theos is not built for x86_64.
+# This happens because theos internally set "$THEOS/vendor/lib" as a search dir,
+# and `PreferenceLoader_LDFLAGS` has lower priority than that.
+# In this hack, we force the linker to search `$THEOS_OBJ_DIR` first by setting `$TARGET_LD`.
+TARGET_LD := $(TARGET_LD) -L$(THEOS_OBJ_DIR)
+
 include locatesim.mk
 
 setup:: all

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -100,7 +100,7 @@ static NSInteger PSSpecifierSort(PSSpecifier *a1, PSSpecifier *a2, void *context
             NSMutableArray *_specifiers = MSHookIvar<NSMutableArray *>(self, "_specifiers");
             NSInteger group, row;
             NSInteger firstindex;
-            if ([self getGroup:(int*)&group row:(int*)&row ofSpecifierID:_Firmware_lt_60 ? @"General" : @"TWITTER"]) {
+            if ([self getGroup:&group row:&row ofSpecifierID:_Firmware_lt_60 ? @"General" : @"TWITTER"]) {
                 firstindex = [self indexOfGroup:group] + [[self specifiersInGroup:group] count];
                 PLLog(@"Adding to the end of group %ld at index %ld", (long)group, (long)firstindex);
             } else {

--- a/locatesim.mk
+++ b/locatesim.mk
@@ -1,8 +1,14 @@
 # fallback to 9.3 here
 PL_SIMULATOR_VERSION := 9.3
-# for Xcode 8 or earlier
-# PL_SIMULATOR_ROOT = /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $(PL_SIMULATOR_VERSION).simruntime/Contents/Resources/RuntimeRoot
+
+PL_XCODE_VERSION := $(shell xcodebuild -version | sed -nE 's/Xcode +([0-9]+)\..*/\1/p')
+ifeq ($(shell [ $(PL_XCODE_VERSION) -ge 9 ]; echo $$?),0)
 # for Xcode 9 or later
 PL_SIMULATOR_ROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
+else
+# for Xcode 8 or earlier
+PL_SIMULATOR_ROOT = /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $(PL_SIMULATOR_VERSION).simruntime/Contents/Resources/RuntimeRoot
+endif
+
 PL_SIMULATOR_BUNDLES_PATH = $(PL_SIMULATOR_ROOT)/Library/PreferenceBundles
 PL_SIMULATOR_PLISTS_PATH = $(PL_SIMULATOR_ROOT)/Library/PreferenceLoader/Preferences

--- a/locatesim.mk
+++ b/locatesim.mk
@@ -1,7 +1,8 @@
 # fallback to 9.3 here
 PL_SIMULATOR_VERSION := 9.3
-PL_SIMULATOR_ROOT = /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $(PL_SIMULATOR_VERSION).simruntime/Contents/Resources/RuntimeRoot
-# for Xcode 9+
-#PL_SIMULATOR_ROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
+# for Xcode 8 or earlier
+# PL_SIMULATOR_ROOT = /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ $(PL_SIMULATOR_VERSION).simruntime/Contents/Resources/RuntimeRoot
+# for Xcode 9 or later
+PL_SIMULATOR_ROOT = /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot
 PL_SIMULATOR_BUNDLES_PATH = $(PL_SIMULATOR_ROOT)/Library/PreferenceBundles
 PL_SIMULATOR_PLISTS_PATH = $(PL_SIMULATOR_ROOT)/Library/PreferenceLoader/Preferences

--- a/prefs.xm
+++ b/prefs.xm
@@ -70,7 +70,7 @@ static BOOL _Firmware_lt_60 = NO;
         PSSpecifier *specifier = [self specifier];
         if (!specifier) {
             NSString *errorText = @"There appears to have been an error restoring these preferences!";
-            return _specifiers = [[NSArray alloc] initWithArray:generateErrorSpecifiersWithText(errorText)];
+            return _specifiers = [generateErrorSpecifiersWithText(errorText) mutableCopy];
         }
         NSString *alternatePlistName = [specifier propertyForKey:PLAlternatePlistNameKey];
         if (alternatePlistName)
@@ -80,7 +80,7 @@ static BOOL _Firmware_lt_60 = NO;
         if (!_specifiers || [_specifiers count] == 0) {
             [_specifiers release];
             NSString *errorText = @"There appears to be an error with these preferences!";
-            _specifiers = [[NSArray alloc] initWithArray:generateErrorSpecifiersWithText(errorText)];
+            _specifiers = [generateErrorSpecifiersWithText(errorText) mutableCopy];
         } else {
             if ([self respondsToSelector:@selector(setTitle:)]) {
                 [self setTitle:specifier.name];
@@ -173,7 +173,7 @@ static BOOL _Firmware_lt_60 = NO;
     if (!_specifiers) {
         PLLog(@"Generating error specifiers for a failed bundle :(");
         NSString *const errorText = [NSString stringWithFormat:@"There was an error loading the preference bundle for %@.", [[self specifier] name]];
-        _specifiers = [[NSArray alloc] initWithArray:generateErrorSpecifiersWithText(errorText)];
+        _specifiers = [generateErrorSpecifiersWithText(errorText) mutableCopy];
     }
     return _specifiers;
 }


### PR DESCRIPTION
- Fixed some compilation errors
- Enabled to switch `PL_SIMULATOR_ROOT` by checking the output of `xcodebuild -version`
- Fixed a link error of `libprefs`

Tested that https://github.com/PoomSmart/SimPref works in the environment below:
- theos: 2.5.0 (40857d)
- simject 1e14ba
- Xcode: 10.3
- iOS Simulator & SDK: 12.4
